### PR TITLE
Fix for File Upload Error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get -y install \
   php5-fpm \
   php5-imap \
   php5-gd \
+  php5-curl \
   php5-mysql && \
   rm -rf /var/lib/apt/lists/*
 

--- a/virtualhost
+++ b/virtualhost
@@ -34,6 +34,14 @@ server {
    	    try_files $uri $uri/ /scp/ajax.php?$query_string;
    	}
 
+    if ($request_uri ~ "^/ajax.php(/[^\?]+)") {
+        set $path_info $1;
+    }
+
+    location ~ ^/ajax.php/.*$ {
+        try_files $uri $uri/ /ajax.php?$query_string;
+    }
+
     location / {
          try_files $uri $uri/ index.php;
     }


### PR DESCRIPTION
When trying to upload attachments to a new ticket without login, the site returns "File Upload Error: <filename> upload404" errors. This fixes those.