### PR TITLE
Allow access to all possible API endpoints

### DIFF
--- a/virtualhost
+++ b/virtualhost
@@ -19,20 +19,20 @@ server {
     }
 
     if ($request_uri ~ "^/api(/[^\?]+)") {
-   	    set $path_info $1;
-  	}
+        set $path_info $1;
+    }
 
-   	location ~ ^/api/(?:tickets|tasks).*$ {
-   	    try_files $uri $uri/ /api/http.php?$query_string;
-   	}
+    location /api {
+        try_files $uri $uri/ /api/http.php?$query_string;
+    }
 
-   	if ($request_uri ~ "^/scp/.*\.php(/[^\?]+)") {
-   	    set $path_info $1;
-   	}
+    if ($request_uri ~ "^/scp/.*\.php(/[^\?]+)") {
+        set $path_info $1;
+    }
 
-   	location ~ ^/scp/ajax.php/.*$ {
-   	    try_files $uri $uri/ /scp/ajax.php?$query_string;
-   	}
+    location ~ ^/scp/ajax.php/.*$ {
+        try_files $uri $uri/ /scp/ajax.php?$query_string;
+    }
 
     if ($request_uri ~ "^/ajax.php(/[^\?]+)") {
         set $path_info $1;


### PR DESCRIPTION
Plugins may be used to extend the API functionality. Therefore, we
need to provide access to all possible API endpoints.