### PR TITLE
Add condition to check if nginx folder exists 

### DIFF
--- a/bin/start.sh
+++ b/bin/start.sh
@@ -13,11 +13,12 @@ php /data/bin/install.php
 echo Applying configuration file security
 chmod 644 /data/upload/include/ost-config.php
 
-mkdir /run/nginx
-chown -R www-data:www-data /run/nginx
-chown -R www-data:www-data /var/lib/nginx
-mkdir /var/log/php
-chown -R www-data:www-data /var/log/php
-
+if [ ! -d "/run/nginx" ]; then
+    mkdir /run/nginx
+    chown -R www-data:www-data /run/nginx
+    chown -R www-data:www-data /var/lib/nginx
+    mkdir /var/log/php
+    chown -R www-data:www-data /var/log/php
+fi
 #Launch supervisor to manage processes
 exec /usr/bin/supervisord -c /data/supervisord.conf


### PR DESCRIPTION
The start.sh script was causing the container to crash if you tried to restart it as the mkdir command returns an error due to the nginx folder already existing, add a condition to avoid this.