### PR TITLE
Fix disabled APCu

### DIFF
--- a/files/usr/local/etc/php/conf.d/php-osticket.ini
+++ b/files/usr/local/etc/php/conf.d/php-osticket.ini
@@ -3,5 +3,6 @@ upload_max_filesize=100M
 post_max_size=100M
 sendmail_path="/usr/bin/msmtp -C /etc/msmtp -t "
 apc.enabled=1
+apc.enable_cli=1
 apc.ttl=7200
 date.timezone=UTC


### PR DESCRIPTION
This change fixes #45 error:
```
PHP Fatal error:  APCuIterator::__construct(): APC must be enabled to use APCuIterator in /data/upload/include/class.search.php on line 966
```