### PR TITLE
Fix iconv bug (empty body when mail encoded in quoted-printable)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,11 @@ ENV HOME=/data
 # setup workdir
 WORKDIR /data
 COPY --from=deployer /data/upload upload
+
+# Fix iconv bug (empty body when mail encoded in quoted-printable)
+RUN apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing gnu-libiconv
+ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
+
 RUN set -x && \
     # requirements and PHP extensions
     apk add --no-cache --update \


### PR DESCRIPTION
Hi !

I had some issue with emails resulting in empty ticket. I narrowed the problem to this state : 

- if the body containes any accentued character (é or à for example)
- if the email has this in his header : "Content-Transfer-Encoding: quoted-printable"

Here are 2 samples of complete email. 
The first one "mail.good" works nicely.
The second "mail.bad" gives an empty ticket.

mail.good:
```
Date: Thu, 7 Feb 2013 11:01:04 -0600
Delivered-To: support@osticket.com
Subject: Testing
From: Peter Rotich <peter@osticket.com>
To: support@osticket.com
Content-Type: text/plain; charset=ISO-8859-1

Testing testing.

```

mail.bad:
```
Date: Thu, 7 Feb 2013 11:01:04 -0600
Delivered-To: support@osticket.com
Subject: Testing
From: Peter Rotich <peter@osticket.com>
To: support@osticket.com
Content-Type: text/plain; charset=ISO-8859-1
Content-Transfer-Encoding: quoted-printable

Testing testing =E9 

```

The difference is "Content-Transfer-Encoding: quoted-printable" in the header and =E9 (encoded é) inside the email body.

To test them inside a container, I use the internal mail piping as :

```sh
php -q /data/upload/api/pipe.php < mail.good
```

To fix that, I used this [fix](https://github.com/docker-library/php/issues/240) and it's now OK for the 2 samples.

Hope it helps.